### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Spec-Driven Development Guide
 
+[![Run in Smithery](https://smithery.ai/badge/skills/jasonkneen)](https://smithery.ai/skills?ns=jasonkneen&utm_source=github&utm_medium=badge)
+
+
 A comprehensive guide to systematic feature development using the three-phase spec process: Requirements → Design → Tasks.
 
 <!-- Navigation Metadata -->


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/jasonkneen)](https://smithery.ai/skills?ns=jasonkneen&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new badge link to the README file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->